### PR TITLE
fix require statement in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ __Version:__ 0.1
     rake ember:i18n:setup
 
 ### in app/assets/javascript/application.js
-    //= require i18n/ember-i18n
+    //= require ember-i18n
     //= require i18n/translations
 
 ## Exporting locales:


### PR DESCRIPTION
Our main file is located under `vendor/assets/javascripts/ember-i18n.js`, so there is no need to prepend the path given to `require`.

Actually, in rails 4.1.x it _only_ works that way.
